### PR TITLE
docs(packages/release-please): fixed syntax

### DIFF
--- a/packages/release-please/README.md
+++ b/packages/release-please/README.md
@@ -72,7 +72,7 @@ options:
 | `draft` | Whether to create the release as a draft | `boolean` | `false` |
 | `draftPullRequest` | Whether to create the pull request as a draft | `boolean` | `false` |
 | `pullRequestTitlePattern` | Customize the pull request title | `string` | |
-| `monorepoTags` | Whether to include the component name in the release | `boolean` | `false |
+| `monorepoTags` | Whether to include the component name in the release | `boolean` | `false` |
 
 ### Usage
 


### PR DESCRIPTION
fixed `BranchConfiguration` section.
monorepoTags default is now escaped

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/repo-automation-bots/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
